### PR TITLE
Updated setttings.py and supervisord.conf

### DIFF
--- a/roles/openslides-add-instance/templates/settings.py.j2
+++ b/roles/openslides-add-instance/templates/settings.py.j2
@@ -16,7 +16,7 @@ STATIC_URL = '/static/'
 STATIC_ROOT = '/data/static/'
 
 CHANNEL_LAYERS['default']['BACKEND'] = 'asgi_redis.RedisChannelLayer'
-CHANNEL_LAYERS['default']['CONFIG']['prefix'] = '{{ openslides_instance_id }}'
+CHANNEL_LAYERS['default']['CONFIG']['prefix'] = 'asgi-{{ openslides_instance_id }}:'
 CHANNEL_LAYERS['default']['CONFIG']['hosts'] = [('172.16.28.1', 6379)]
 
 CACHES = {
@@ -25,7 +25,8 @@ CACHES = {
        "LOCATION": "redis://172.16.28.1:6379/0",
        "OPTIONS": {
            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-       }
+       },
+       "KEY_PREFIX": "openslides-cache-{{ openslides_instance_id }}'",
    }
 }
 

--- a/roles/openslides-add-instance/templates/supervisord.conf.j2
+++ b/roles/openslides-add-instance/templates/supervisord.conf.j2
@@ -9,8 +9,28 @@ command=/usr/local/bin/daphne openslides.asgi:channel_layer -p 8000 -b 0.0.0.0
 stdout_logfile=/data/openslides.out
 stderr_logfile=/data/openslides.err
 directory=/tmp
+autorestart=true
 
 [program:openslides_worker_1]
 command=/app/manage.py runworker
 stdout_logfile=/data/openslides_worker_1.out
 stderr_logfile=/data/openslides_worker_1.err
+autorestart=true
+
+[program:openslides_worker_2]
+command=/app/manage.py runworker
+stdout_logfile=/data/openslides_worker_2.out
+stderr_logfile=/data/openslides_worker_2.err
+autorestart=true
+
+[program:openslides_worker_3]
+command=/app/manage.py runworker
+stdout_logfile=/data/openslides_worker_3.out
+stderr_logfile=/data/openslides_worker_3.err
+autorestart=true
+
+[program:openslides_worker_4]
+command=/app/manage.py runworker
+stdout_logfile=/data/openslides_worker_4.out
+stderr_logfile=/data/openslides_worker_4.err
+autorestart=true


### PR DESCRIPTION
- Use unique redis cache prefix.
- Use 4 workers by default.
- Use 'autorestart' for workers and daphne.