### PR TITLE
Avoid PostgreSQL & Redis restarts

### DIFF
--- a/roles/openslides-add-instance/tasks/init_instance_database.yml
+++ b/roles/openslides-add-instance/tasks/init_instance_database.yml
@@ -27,20 +27,6 @@
                    priv=ALL
                    state=present
 
-- name: restart postgresql to make sure it bind to veth ip
-  sudo: yes
-  sudo_user: root
-  service:
-    name: postgresql
-    state: restarted
-
-- name: restart redis to make sure it bind to veth ip
-  sudo: yes
-  sudo_user: root
-  service:
-    name: redis-server
-    state: restarted
-
 - name: Migrate database
   sudo: yes
   sudo_user: root


### PR DESCRIPTION
Presumably, these restarts were added as a workaround for the fact that
the Rocket network interface may not become available immediately after
a reboot.  In that case Postgres and Redis would start but not listen on
the desired interface.  The first time a Rocket container is started,
the interface will be created; restarting the services afterwards would
ensure that they start listening on the interface.

Obviously, automatically restarting these services every time an
instance is created is not ideal.

The alternative is to configure a network interface according to the
README.md (tap0) which ensures the Interface is available early on.

This patch simply removes the restart tasks.  The README already
contains the necessary information.

See also
https://github.com/OpenSlides/openslides-multiinstance-backend/issues/23.